### PR TITLE
Remove setuptools, wheel from build-system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 35.0.2", "wheel >= 0.29.0", "poetry_core>=1.0.0"]
+requires = ["poetry_core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]


### PR DESCRIPTION
Looks like the project gets built using poetry-core since 1.2.0. That should make setuptools and wheel redundant.